### PR TITLE
[BUGFIX] Check if a file exists before fetching its stats

### DIFF
--- a/src/BypassFinals.php
+++ b/src/BypassFinals.php
@@ -186,6 +186,10 @@ class BypassFinals
 
 	public function url_stat($path, $flags)
 	{
+		if (!$this->native('file_exists', $path)) {
+			return null;
+		}
+
 		return $this->native(
 			$flags & STREAM_URL_STAT_LINK ? 'lstat' : 'stat',
 			$path


### PR DESCRIPTION
Prevents a warning being thrown when a file does not exist on the filesystem.

Fixes #1